### PR TITLE
Dl pr cleanup

### DIFF
--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -5,7 +5,7 @@ class Customer < ApplicationRecord
   has_many :items, through: :invoices
 
   def self.successful_transactions
-    joins(:transactions).where("transactions.result = 'success'")
+    joins(:transactions).where("transactions.result = 1")
   end
 
   def self.order_by_purchases

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -8,7 +8,7 @@ class Merchant < ApplicationRecord
   def self.top5(id)
     Customer
     .joins(:merchants, :transactions)
-    .where("transactions.result = 0 AND merchants.id = #{id}")
+    .where("transactions.result = 1 AND merchants.id = #{id}")
     .group(:id)
     .select('first_name, last_name, count(customers) AS transactions_count')
     .order(transactions_count: :desc)

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -1,4 +1,6 @@
 class Transaction < ApplicationRecord
   belongs_to :invoice
   has_many :merchants, through: :invoice
+
+  enum result: ["failed", "success"]
 end

--- a/db/migrate/20230102223527_create_transactions.rb
+++ b/db/migrate/20230102223527_create_transactions.rb
@@ -3,7 +3,7 @@ class CreateTransactions < ActiveRecord::Migration[5.2]
     create_table :transactions do |t|
       t.string :credit_card_number
       t.string :credit_card_expiration_date
-      t.integer :result, default: 0
+      t.integer :result, default: 1
       t.references :invoice, null: false, foreign_key: true
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -61,7 +61,7 @@ ActiveRecord::Schema.define(version: 2023_01_02_223657) do
   create_table "transactions", force: :cascade do |t|
     t.string "credit_card_number"
     t.string "credit_card_expiration_date"
-    t.integer "result", default: 0
+    t.integer "result", default: 1
     t.bigint "invoice_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/spec/features/merchants/invoices/index_spec.rb
+++ b/spec/features/merchants/invoices/index_spec.rb
@@ -40,8 +40,8 @@ RSpec.describe 'merchants invoices index page' do
   it 'displays each invoice id as a link to the merchant invoice show page' do
     visit merchant_invoices_path(@merchant1)
 
-    expect(page).to have_link @invoice1.id, href: invoice_path(@invoice1)
-    expect(page).to have_link @invoice2.id, href: invoice_path(@invoice2)
-    expect(page).to have_no_link @invoice3.id, href: invoice_path(@invoice3)
+    expect(page).to have_link @invoice1.id.to_s, href: invoice_path(@invoice1)
+    expect(page).to have_link @invoice2.id.to_s, href: invoice_path(@invoice2)
+    expect(page).to have_no_link @invoice3.id.to_s, href: invoice_path(@invoice3)
   end
 end

--- a/spec/features/merchants/show_spec.rb
+++ b/spec/features/merchants/show_spec.rb
@@ -169,4 +169,125 @@ RSpec.describe 'merchant show' do
     expect(page).to_not have_content("Name: Sixth Guy, Transactions: 1")
     end
   end
+
+  describe 'Items Ready to Ship Section' do
+    it 'has section titled Items Ready to Ship' do
+      merchant1 = Merchant.create!(name: 'Rays Hand Made Jewlery')
+      visit merchant_dashboards_path(merchant1.id)
+      expect(page).to have_css('section#packaged')
+      expect(page).to have_content('Items Ready to Ship')
+    end
+
+    it 'lists names of all ordered, unshipped items' do
+      merchant1 = Merchant.create!(name: 'Rays Hand Made Jewlery')
+
+      item1 = Item.create!(name: 'Chips', description: 'Ring', unit_price: 20, merchant_id: merchant1.id)
+      item2 = Item.create!(name: 'darrel', description: 'Bracelet', unit_price: 40, merchant_id: merchant1.id)
+      item3 = Item.create!(name: 'don', description: 'Necklace', unit_price: 30, merchant_id: merchant1.id)
+
+      customer1 = Customer.create!(first_name: 'Kyle', last_name: 'Ledin')
+      invoice1 = Invoice.create!(status: 1, customer_id: customer1.id)
+      ii1 = InvoiceItem.create!(quantity: 5, unit_price: item1.unit_price, item_id: item1.id,
+                                invoice_id: invoice1.id)
+      ii2 = InvoiceItem.create!(quantity: 5, unit_price: item2.unit_price, item_id: item2.id,
+                                invoice_id: invoice1.id)
+      ii3 = InvoiceItem.create!(quantity: 5, unit_price: item3.unit_price, item_id: item3.id,
+                                invoice_id: invoice1.id)
+      visit merchant_dashboards_path(merchant1.id)
+
+      expect(page).to have_content(item1.name)
+      expect(page).to have_content(item2.name)
+      expect(page).to have_content(item3.name)
+    end
+
+    it 'lists invoice id next to item name' do
+      merchant1 = Merchant.create!(name: 'Rays Hand Made Jewlery')
+
+      item1 = Item.create!(name: 'Chips', description: 'Ring', unit_price: 20, merchant_id: merchant1.id)
+      item2 = Item.create!(name: 'darrel', description: 'Bracelet', unit_price: 40, merchant_id: merchant1.id)
+      item3 = Item.create!(name: 'don', description: 'Necklace', unit_price: 30, merchant_id: merchant1.id)
+
+      customer1 = Customer.create!(first_name: 'Kyle', last_name: 'Ledin')
+      invoice1 = Invoice.create!(status: 1, customer_id: customer1.id)
+      ii1 = InvoiceItem.create!(quantity: 5, unit_price: item1.unit_price, item_id: item1.id,
+                                invoice_id: invoice1.id)
+      ii2 = InvoiceItem.create!(quantity: 5, unit_price: item2.unit_price, item_id: item2.id,
+                                invoice_id: invoice1.id)
+      ii3 = InvoiceItem.create!(quantity: 5, unit_price: item3.unit_price, item_id: item3.id,
+                                invoice_id: invoice1.id)
+      visit merchant_dashboards_path(merchant1.id)
+      expect(page).to have_content(invoice1.id)
+    end
+
+    it 'links to merchants invoice show page from invoice id' do
+      merchant1 = Merchant.create!(name: 'Rays Hand Made Jewlery')
+
+      item1 = Item.create!(name: 'Chips', description: 'Ring', unit_price: 20, merchant_id: merchant1.id)
+      item2 = Item.create!(name: 'darrel', description: 'Bracelet', unit_price: 40, merchant_id: merchant1.id)
+      item3 = Item.create!(name: 'don', description: 'Necklace', unit_price: 30, merchant_id: merchant1.id)
+
+      customer1 = Customer.create!(first_name: 'Kyle', last_name: 'Ledin')
+      invoice1 = Invoice.create!(status: 1, customer_id: customer1.id)
+      ii1 = InvoiceItem.create!(quantity: 5, unit_price: item1.unit_price, item_id: item1.id,
+                                invoice_id: invoice1.id)
+      ii2 = InvoiceItem.create!(quantity: 5, unit_price: item2.unit_price, item_id: item2.id,
+                                invoice_id: invoice1.id)
+      ii3 = InvoiceItem.create!(quantity: 5, unit_price: item3.unit_price, item_id: item3.id,
+                                invoice_id: invoice1.id)
+
+      visit merchant_dashboards_path(merchant1.id)
+      within("#invoice#{invoice1.id}-item#{item1.id}") do
+        click_on invoice1.id.to_s
+      end
+
+      expect(current_path).to eq(invoice_path(invoice1))
+    end
+
+    it 'lists invoice creation date next to each item' do
+      merchant1 = Merchant.create!(name: 'Rays Hand Made Jewlery')
+
+      item1 = Item.create!(name: 'Chips', description: 'Ring', unit_price: 20, merchant_id: merchant1.id)
+      item2 = Item.create!(name: 'darrel', description: 'Bracelet', unit_price: 40, merchant_id: merchant1.id)
+      item3 = Item.create!(name: 'don', description: 'Necklace', unit_price: 30, merchant_id: merchant1.id)
+
+      customer1 = Customer.create!(first_name: 'Kyle', last_name: 'Ledin')
+      invoice1 = Invoice.create!(status: 1, customer_id: customer1.id)
+      ii1 = InvoiceItem.create!(quantity: 5, unit_price: item1.unit_price, item_id: item1.id,
+                                invoice_id: invoice1.id)
+      ii2 = InvoiceItem.create!(quantity: 5, unit_price: item2.unit_price, item_id: item2.id,
+                                invoice_id: invoice1.id)
+      ii3 = InvoiceItem.create!(quantity: 5, unit_price: item3.unit_price, item_id: item3.id,
+                                invoice_id: invoice1.id)
+
+      visit merchant_dashboards_path(merchant1.id)
+
+      within("#invoice#{invoice1.id}-item#{item1.id}") do
+        expect(page).to have_content(invoice1.created_at.strftime('%A, %B%e, %Y'))
+      end
+    end
+    
+    it 'orders list from oldest invoice creation to newest' do
+      merchant1 = Merchant.create!(name: 'Rays Hand Made Jewlery')
+
+      item1 = Item.create!(name: 'Chips', description: 'Ring', unit_price: 20, merchant_id: merchant1.id)
+      # item2 = Item.create!(name: 'darrel', description: 'Bracelet', unit_price: 40, merchant_id: merchant1.id)
+      # item3 = Item.create!(name: 'don', description: 'Necklace', unit_price: 30, merchant_id: merchant1.id)
+
+      customer1 = Customer.create!(first_name: 'Kyle', last_name: 'Ledin')
+      invoice1 = Invoice.create!(status: 1, customer_id: customer1.id)
+      invoice2 = Invoice.create!(status: 1, customer_id: customer1.id)
+      invoice3 = Invoice.create!(status: 1, customer_id: customer1.id)
+      ii1 = InvoiceItem.create!(quantity: 5, unit_price: item1.unit_price, item_id: item1.id, invoice_id: invoice1.id)
+      ii2 = InvoiceItem.create!(quantity: 5, unit_price: item1.unit_price, item_id: item1.id, invoice_id: invoice2.id)
+      ii3 = InvoiceItem.create!(quantity: 5, unit_price: item1.unit_price, item_id: item1.id, invoice_id: invoice3.id)
+      # ii2 = InvoiceItem.create!(quantity: 5, unit_price: item2.unit_price, item_id: item2.id,
+                                # invoice_id: invoice1.id)
+      # ii3 = InvoiceItem.create!(quantity: 5, unit_price: item3.unit_price, item_id: item3.id,
+                                # invoice_id: invoice1.id)
+
+      visit merchant_dashboards_path(merchant1.id)
+
+      expect(invoice1.id.to_s).to appear_before(invoice2.id.to_s)
+    end
+  end
 end

--- a/spec/features/merchants/show_spec.rb
+++ b/spec/features/merchants/show_spec.rb
@@ -1,256 +1,64 @@
 require 'rails_helper'
 
 RSpec.describe 'merchant show' do
+  before :each do
+    @merchant1 = Merchant.create!(name: 'Rays Hand Made Jewlery')
+    @merchant2 = Merchant.create!(name: 'Jays Foot Made Jewlery')
+
+    @item1 = Item.create!(name: 'Chips', description: 'Ring', unit_price: 20, merchant_id: @merchant1.id)
+    @item2 = Item.create!(name: 'darrel', description: 'Bracelet', unit_price: 40, merchant_id: @merchant1.id)
+    @item3 = Item.create!(name: 'don', description: 'Necklace', unit_price: 30, merchant_id: @merchant1.id)
+
+    @item4 = Item.create!(name: 'fake', description: 'Toe Ring', unit_price: 30, merchant_id: @merchant2.id)
+
+    @customer1 = Customer.create!(first_name: 'Kyle', last_name: 'Ledin')
+    @customer2 = Customer.create!(first_name: 'William', last_name: 'Lampke')
+
+    @invoice1 = Invoice.create!(status: 1, customer_id: @customer1.id)
+    @invoice2 = Invoice.create!(status: 1, customer_id: @customer1.id)
+    @invoice3 = Invoice.create!(status: 1, customer_id: @customer1.id)
+
+    @invoice4 = Invoice.create!(status: 1, customer_id: @customer2.id)
+
+    @transaction1 = Transaction.create!(credit_card_number: '123456789', credit_card_expiration_date: '05/07', invoice_id: @invoice1.id)
+    @transaction2 = Transaction.create!(credit_card_number: '987654321', credit_card_expiration_date: '04/07', invoice_id: @invoice2.id)
+    @transaction3 = Transaction.create!(credit_card_number: '543219876', credit_card_expiration_date: '03/07', invoice_id: @invoice3.id)
+
+    @transaction4 = Transaction.create!(credit_card_number: '121987654', credit_card_expiration_date: '02/07', invoice_id: @invoice4.id)
+
+    @ii1 = InvoiceItem.create!(quantity: 5, unit_price: @item1.unit_price, item_id: @item1.id, invoice_id: @invoice1.id)
+    @ii2 = InvoiceItem.create!(quantity: 5, unit_price: @item2.unit_price, item_id: @item2.id, invoice_id: @invoice2.id)
+    @ii3 = InvoiceItem.create!(quantity: 5, unit_price: @item3.unit_price, item_id: @item3.id, invoice_id: @invoice3.id)
+
+    @ii4 = InvoiceItem.create!(quantity: 5, unit_price: @item4.unit_price, item_id: @item4.id, invoice_id: @invoice4.id)
+  end
+
   describe 'story 1' do
+    #   As a merchant,
+    # When I visit my merchant dashboard (/merchants/merchant_id/dashboard)
+    # Then I see the name of my merchant
     it 'shows the name of the merchant' do
-      @merchant1 = Merchant.create!(name: 'Rays Hand Made Jewlery')
-      @merchant2 = Merchant.create!(name: 'Jays Foot Made Jewlery')
-
-      @item1 = Item.create!(name: 'Chips', description: 'Ring', unit_price: 20, merchant_id: @merchant1.id)
-      @item2 = Item.create!(name: 'darrel', description: 'Bracelet', unit_price: 40, merchant_id: @merchant1.id)
-      @item3 = Item.create!(name: 'don', description: 'Necklace', unit_price: 30, merchant_id: @merchant1.id)
-
-      @item4 = Item.create!(name: 'fake', description: 'Toe Ring', unit_price: 30, merchant_id: @merchant2.id)
-
-      @customer1 = Customer.create!(first_name: 'Kyle', last_name: 'Ledin')
-      @customer2 = Customer.create!(first_name: 'William', last_name: 'Lampke')
-
-      @invoice1 = Invoice.create!(status: 1, customer_id: @customer1.id)
-      @invoice2 = Invoice.create!(status: 1, customer_id: @customer1.id)
-      @invoice3 = Invoice.create!(status: 1, customer_id: @customer1.id)
-      @invoice4 = Invoice.create!(status: 1, customer_id: @customer2.id)
-
-      @transaction1 = Transaction.create!(credit_card_number: '123456789', credit_card_expiration_date: '05/07', invoice_id: @invoice1.id)
-      @transaction2 = Transaction.create!(credit_card_number: '987654321', credit_card_expiration_date: '04/07', invoice_id: @invoice2.id)
-      @transaction3 = Transaction.create!(credit_card_number: '543219876', credit_card_expiration_date: '03/07', invoice_id: @invoice3.id)
-      @transaction4 = Transaction.create!(credit_card_number: '121987654', credit_card_expiration_date: '02/07', invoice_id: @invoice4.id)
-
-      @transaction1 = Transaction.create!(credit_card_number: '123456789', credit_card_expiration_date: '05/07',
-                                          invoice_id: @invoice1.id)
-      @transaction2 = Transaction.create!(credit_card_number: '987654321', credit_card_expiration_date: '04/07',
-                                          invoice_id: @invoice2.id)
-      @transaction3 = Transaction.create!(credit_card_number: '543219876', credit_card_expiration_date: '03/07',
-                                          invoice_id: @invoice3.id)
-      @transaction4 = Transaction.create!(credit_card_number: '121987654', credit_card_expiration_date: '02/07',
-                                          invoice_id: @invoice4.id)
-
-      @ii1 = InvoiceItem.create!(quantity: 5, unit_price: @item1.unit_price, item_id: @item1.id,
-                                 invoice_id: @invoice1.id)
-      @ii2 = InvoiceItem.create!(quantity: 5, unit_price: @item2.unit_price, item_id: @item2.id,
-                                 invoice_id: @invoice2.id)
-      @ii3 = InvoiceItem.create!(quantity: 5, unit_price: @item3.unit_price, item_id: @item3.id,
-                                 invoice_id: @invoice3.id)
-      @ii4 = InvoiceItem.create!(quantity: 5, unit_price: @item4.unit_price, item_id: @item4.id,
-                                 invoice_id: @invoice4.id)
-                                 
       visit "merchants/#{@merchant1.id}/dashboards"
-      
       expect(page).to have_content(@merchant1.name)
     end
   end
 
   describe 'story 2' do
-    it 'has a link to the merchant items index' do
-      @merchant1 = Merchant.create!(name: 'Rays Hand Made Jewlery')
-      @merchant2 = Merchant.create!(name: 'Jays Foot Made Jewlery')
-
-      @item1 = Item.create!(name: 'Chips', description: 'Ring', unit_price: 20, merchant_id: @merchant1.id)
-      @item2 = Item.create!(name: 'darrel', description: 'Bracelet', unit_price: 40, merchant_id: @merchant1.id)
-      @item3 = Item.create!(name: 'don', description: 'Necklace', unit_price: 30, merchant_id: @merchant1.id)
-      @item4 = Item.create!(name: 'fake', description: 'Toe Ring', unit_price: 30, merchant_id: @merchant2.id)
-
-      @customer1 = Customer.create!(first_name: 'Kyle', last_name: 'Ledin')
-      @customer2 = Customer.create!(first_name: 'William', last_name: 'Lampke')
-
-      @invoice1 = Invoice.create!(status: 1, customer_id: @customer1.id)
-      @invoice2 = Invoice.create!(status: 1, customer_id: @customer1.id)
-      @invoice3 = Invoice.create!(status: 1, customer_id: @customer1.id)
-
-      @invoice4 = Invoice.create!(status: 1, customer_id: @customer2.id)
-
-      @transaction1 = Transaction.create!(credit_card_number: '123456789', credit_card_expiration_date: '05/07',
-                                          invoice_id: @invoice1.id)
-      @transaction2 = Transaction.create!(credit_card_number: '987654321', credit_card_expiration_date: '04/07',
-                                          invoice_id: @invoice2.id)
-      @transaction3 = Transaction.create!(credit_card_number: '543219876', credit_card_expiration_date: '03/07',
-                                          invoice_id: @invoice3.id)
-
-      @transaction4 = Transaction.create!(credit_card_number: '121987654', credit_card_expiration_date: '02/07',
-                                          invoice_id: @invoice4.id)
-
-      @ii1 = InvoiceItem.create!(quantity: 5, unit_price: @item1.unit_price, item_id: @item1.id,
-                                 invoice_id: @invoice1.id)
-      @ii2 = InvoiceItem.create!(quantity: 5, unit_price: @item2.unit_price, item_id: @item2.id,
-                                 invoice_id: @invoice2.id)
-      @ii3 = InvoiceItem.create!(quantity: 5, unit_price: @item3.unit_price, item_id: @item3.id,
-                                 invoice_id: @invoice3.id)
-
-      @ii4 = InvoiceItem.create!(quantity: 5, unit_price: @item4.unit_price, item_id: @item4.id,
-                                 invoice_id: @invoice4.id)
+#     As a merchant,
+# When I visit my merchant dashboard
+# Then I see link to my merchant items index (/merchants/merchant_id/items)
+# And I see a link to my merchant invoices index (/merchants/merchant_id/invoices)
+    it "has a link to the merchant items index" do
       visit "merchants/#{@merchant1.id}/dashboards"
-
+      
       expect(page).to have_link("#{@merchant1.name} items")
     end
-
-    it 'has a link to the merchant invoices index' do
-      @merchant1 = Merchant.create!(name: 'Rays Hand Made Jewlery')
-      @merchant2 = Merchant.create!(name: 'Jays Foot Made Jewlery')
-
-      @item1 = Item.create!(name: 'Chips', description: 'Ring', unit_price: 20, merchant_id: @merchant1.id)
-      @item2 = Item.create!(name: 'darrel', description: 'Bracelet', unit_price: 40, merchant_id: @merchant1.id)
-      @item3 = Item.create!(name: 'don', description: 'Necklace', unit_price: 30, merchant_id: @merchant1.id)
-      @item4 = Item.create!(name: 'fake', description: 'Toe Ring', unit_price: 30, merchant_id: @merchant2.id)
-
-      @customer1 = Customer.create!(first_name: 'Kyle', last_name: 'Ledin')
-      @customer2 = Customer.create!(first_name: 'William', last_name: 'Lampke')
-
-      @invoice1 = Invoice.create!(status: 1, customer_id: @customer1.id)
-      @invoice2 = Invoice.create!(status: 1, customer_id: @customer1.id)
-      @invoice3 = Invoice.create!(status: 1, customer_id: @customer1.id)
-      @invoice4 = Invoice.create!(status: 1, customer_id: @customer2.id)
-
-      @transaction1 = Transaction.create!(credit_card_number: '123456789', credit_card_expiration_date: '05/07',
-                                          invoice_id: @invoice1.id)
-      @transaction2 = Transaction.create!(credit_card_number: '987654321', credit_card_expiration_date: '04/07',
-                                          invoice_id: @invoice2.id)
-      @transaction3 = Transaction.create!(credit_card_number: '543219876', credit_card_expiration_date: '03/07',
-                                          invoice_id: @invoice3.id)
-
-      @transaction4 = Transaction.create!(credit_card_number: '121987654', credit_card_expiration_date: '02/07',
-                                          invoice_id: @invoice4.id)
-
-      @ii1 = InvoiceItem.create!(quantity: 5, unit_price: @item1.unit_price, item_id: @item1.id,
-                                 invoice_id: @invoice1.id)
-      @ii2 = InvoiceItem.create!(quantity: 5, unit_price: @item2.unit_price, item_id: @item2.id,
-                                 invoice_id: @invoice2.id)
-      @ii3 = InvoiceItem.create!(quantity: 5, unit_price: @item3.unit_price, item_id: @item3.id,
-                                 invoice_id: @invoice3.id)
-      @ii4 = InvoiceItem.create!(quantity: 5, unit_price: @item4.unit_price, item_id: @item4.id,
-                                 invoice_id: @invoice4.id)
-      visit "merchants/#{@merchant1.id}/dashboards"
-
-      expect(page).to have_link("#{@merchant1.name} invoices")
-    end
-  end
-
-  describe 'Items Ready to Ship Section' do
-    it 'has section titled Items Ready to Ship' do
-      merchant1 = Merchant.create!(name: 'Rays Hand Made Jewlery')
-      visit merchant_dashboards_path(merchant1.id)
-      expect(page).to have_css('section#packaged')
-      expect(page).to have_content('Items Ready to Ship')
-    end
-
-    it 'lists names of all ordered, unshipped items' do
-      merchant1 = Merchant.create!(name: 'Rays Hand Made Jewlery')
-
-      item1 = Item.create!(name: 'Chips', description: 'Ring', unit_price: 20, merchant_id: merchant1.id)
-      item2 = Item.create!(name: 'darrel', description: 'Bracelet', unit_price: 40, merchant_id: merchant1.id)
-      item3 = Item.create!(name: 'don', description: 'Necklace', unit_price: 30, merchant_id: merchant1.id)
-
-      customer1 = Customer.create!(first_name: 'Kyle', last_name: 'Ledin')
-      invoice1 = Invoice.create!(status: 1, customer_id: customer1.id)
-      ii1 = InvoiceItem.create!(quantity: 5, unit_price: item1.unit_price, item_id: item1.id,
-                                invoice_id: invoice1.id)
-      ii2 = InvoiceItem.create!(quantity: 5, unit_price: item2.unit_price, item_id: item2.id,
-                                invoice_id: invoice1.id)
-      ii3 = InvoiceItem.create!(quantity: 5, unit_price: item3.unit_price, item_id: item3.id,
-                                invoice_id: invoice1.id)
-      visit merchant_dashboards_path(merchant1.id)
-
-      expect(page).to have_content(item1.name)
-      expect(page).to have_content(item2.name)
-      expect(page).to have_content(item3.name)
-    end
-
-    it 'lists invoice id next to item name' do
-      merchant1 = Merchant.create!(name: 'Rays Hand Made Jewlery')
-
-      item1 = Item.create!(name: 'Chips', description: 'Ring', unit_price: 20, merchant_id: merchant1.id)
-      item2 = Item.create!(name: 'darrel', description: 'Bracelet', unit_price: 40, merchant_id: merchant1.id)
-      item3 = Item.create!(name: 'don', description: 'Necklace', unit_price: 30, merchant_id: merchant1.id)
-
-      customer1 = Customer.create!(first_name: 'Kyle', last_name: 'Ledin')
-      invoice1 = Invoice.create!(status: 1, customer_id: customer1.id)
-      ii1 = InvoiceItem.create!(quantity: 5, unit_price: item1.unit_price, item_id: item1.id,
-                                invoice_id: invoice1.id)
-      ii2 = InvoiceItem.create!(quantity: 5, unit_price: item2.unit_price, item_id: item2.id,
-                                invoice_id: invoice1.id)
-      ii3 = InvoiceItem.create!(quantity: 5, unit_price: item3.unit_price, item_id: item3.id,
-                                invoice_id: invoice1.id)
-      visit merchant_dashboards_path(merchant1.id)
-      expect(page).to have_content(invoice1.id)
-    end
-
-    it 'links to merchants invoice show page from invoice id' do
-      merchant1 = Merchant.create!(name: 'Rays Hand Made Jewlery')
-
-      item1 = Item.create!(name: 'Chips', description: 'Ring', unit_price: 20, merchant_id: merchant1.id)
-      item2 = Item.create!(name: 'darrel', description: 'Bracelet', unit_price: 40, merchant_id: merchant1.id)
-      item3 = Item.create!(name: 'don', description: 'Necklace', unit_price: 30, merchant_id: merchant1.id)
-
-      customer1 = Customer.create!(first_name: 'Kyle', last_name: 'Ledin')
-      invoice1 = Invoice.create!(status: 1, customer_id: customer1.id)
-      ii1 = InvoiceItem.create!(quantity: 5, unit_price: item1.unit_price, item_id: item1.id,
-                                invoice_id: invoice1.id)
-      ii2 = InvoiceItem.create!(quantity: 5, unit_price: item2.unit_price, item_id: item2.id,
-                                invoice_id: invoice1.id)
-      ii3 = InvoiceItem.create!(quantity: 5, unit_price: item3.unit_price, item_id: item3.id,
-                                invoice_id: invoice1.id)
-
-      visit merchant_dashboards_path(merchant1.id)
-      within("#invoice#{invoice1.id}-item#{item1.id}") do
-        click_on invoice1.id.to_s
-      end
-
-      expect(current_path).to eq(invoice_path(invoice1))
-    end
-
-    it 'lists invoice creation date next to each item' do
-      merchant1 = Merchant.create!(name: 'Rays Hand Made Jewlery')
-
-      item1 = Item.create!(name: 'Chips', description: 'Ring', unit_price: 20, merchant_id: merchant1.id)
-      item2 = Item.create!(name: 'darrel', description: 'Bracelet', unit_price: 40, merchant_id: merchant1.id)
-      item3 = Item.create!(name: 'don', description: 'Necklace', unit_price: 30, merchant_id: merchant1.id)
-
-      customer1 = Customer.create!(first_name: 'Kyle', last_name: 'Ledin')
-      invoice1 = Invoice.create!(status: 1, customer_id: customer1.id)
-      ii1 = InvoiceItem.create!(quantity: 5, unit_price: item1.unit_price, item_id: item1.id,
-                                invoice_id: invoice1.id)
-      ii2 = InvoiceItem.create!(quantity: 5, unit_price: item2.unit_price, item_id: item2.id,
-                                invoice_id: invoice1.id)
-      ii3 = InvoiceItem.create!(quantity: 5, unit_price: item3.unit_price, item_id: item3.id,
-                                invoice_id: invoice1.id)
-
-      visit merchant_dashboards_path(merchant1.id)
-
-      within("#invoice#{invoice1.id}-item#{item1.id}") do
-        expect(page).to have_content(invoice1.created_at.strftime('%A, %B%e, %Y'))
-      end
-    end
     
-    it 'orders list from oldest invoice creation to newest' do
-      merchant1 = Merchant.create!(name: 'Rays Hand Made Jewlery')
-
-      item1 = Item.create!(name: 'Chips', description: 'Ring', unit_price: 20, merchant_id: merchant1.id)
-      # item2 = Item.create!(name: 'darrel', description: 'Bracelet', unit_price: 40, merchant_id: merchant1.id)
-      # item3 = Item.create!(name: 'don', description: 'Necklace', unit_price: 30, merchant_id: merchant1.id)
-
-      customer1 = Customer.create!(first_name: 'Kyle', last_name: 'Ledin')
-      invoice1 = Invoice.create!(status: 1, customer_id: customer1.id)
-      invoice2 = Invoice.create!(status: 1, customer_id: customer1.id)
-      invoice3 = Invoice.create!(status: 1, customer_id: customer1.id)
-      ii1 = InvoiceItem.create!(quantity: 5, unit_price: item1.unit_price, item_id: item1.id, invoice_id: invoice1.id)
-      ii2 = InvoiceItem.create!(quantity: 5, unit_price: item1.unit_price, item_id: item1.id, invoice_id: invoice2.id)
-      ii3 = InvoiceItem.create!(quantity: 5, unit_price: item1.unit_price, item_id: item1.id, invoice_id: invoice3.id)
-      # ii2 = InvoiceItem.create!(quantity: 5, unit_price: item2.unit_price, item_id: item2.id,
-                                # invoice_id: invoice1.id)
-      # ii3 = InvoiceItem.create!(quantity: 5, unit_price: item3.unit_price, item_id: item3.id,
-                                # invoice_id: invoice1.id)
-
-      visit merchant_dashboards_path(merchant1.id)
-
-      expect(invoice1.id).to appear_before(invoice2.id)
+    it "has a link to the merchant invoices index" do
+      visit "merchants/#{@merchant1.id}/dashboards"
+      
+      expect(page).to have_link("#{@merchant1.name} invoices")
+      
     end
   end
   describe 'story 3' do
@@ -362,4 +170,3 @@ RSpec.describe 'merchant show' do
     end
   end
 end
-

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -39,7 +39,6 @@ RSpec.describe Merchant do
     it {should have_many(:invoices).through(:invoice_items)}
     it {should have_many(:customers).through(:invoices)}
     it {should have_many(:transactions).through(:invoices)}
-
   end
   
   describe "#top5" do
@@ -69,8 +68,6 @@ RSpec.describe Merchant do
       transaction8 = Transaction.create!(credit_card_number: '121987654', credit_card_expiration_date: '02/07', invoice_id: invoice8.id)
       ii8 = InvoiceItem.create!(quantity: 5, unit_price: item8.unit_price, item_id: item8.id, invoice_id: invoice8.id)    
       
-  
-      
       item9 = Item.create!(name: 'fak121212e', description: 'T121212ing', unit_price: 30, merchant_id: @merchant1.id)
       invoice9 = Invoice.create!(status: 1, customer_id: customer3.id)
       transaction9 = Transaction.create!(credit_card_number: '121987654', credit_card_expiration_date: '02/07', invoice_id: invoice9.id)
@@ -86,8 +83,6 @@ RSpec.describe Merchant do
       transaction11 = Transaction.create!(credit_card_number: '121987654', credit_card_expiration_date: '02/07', invoice_id: invoice11.id)
       ii11 = InvoiceItem.create!(quantity: 5, unit_price: item11.unit_price, item_id: item11.id, invoice_id: invoice11.id)
       
-  
-  
       item12 = Item.create!(name: 'fak121212e', description: 'T121212ing', unit_price: 30, merchant_id: @merchant1.id)
       invoice12 = Invoice.create!(status: 1, customer_id: customer4.id)
       transaction12 = Transaction.create!(credit_card_number: '121987654', credit_card_expiration_date: '02/07', invoice_id: invoice12.id)
@@ -123,12 +118,10 @@ RSpec.describe Merchant do
       transaction18 = Transaction.create!(credit_card_number: '121987654', credit_card_expiration_date: '02/07', invoice_id: invoice18.id)
       ii18 = InvoiceItem.create!(quantity: 5, unit_price: item18.unit_price, item_id: item18.id, invoice_id: invoice18.id)
       
-  
       item19 = Item.create!(name: 'fak121212e', description: 'T121212ing', unit_price: 30, merchant_id: @merchant1.id)
       invoice19 = Invoice.create!(status: 1, customer_id: @customer1.id)
       transaction19 = Transaction.create!(credit_card_number: '121987654', credit_card_expiration_date: '02/07', invoice_id: invoice19.id)
       ii19 = InvoiceItem.create!(quantity: 5, unit_price: item19.unit_price, item_id: item19.id, invoice_id: invoice19.id)
-  
   
       item20 = Item.create!(name: 'fak121212e', description: 'T121212ing', unit_price: 30, merchant_id: @merchant1.id)
       invoice20 = Invoice.create!(status: 1, customer_id: customer3.id)
@@ -141,6 +134,7 @@ RSpec.describe Merchant do
       expect(Merchant.top5(@merchant1.id).fourth.transactions_count).to eq(9)
       expect(Merchant.top5(@merchant1.id).fifth.transactions_count).to eq(4)
     end
+  end
 
   describe 'instance methods' do
     describe '#pending_invoices' do

--- a/spec/models/transaction_spec.rb
+++ b/spec/models/transaction_spec.rb
@@ -32,13 +32,7 @@ RSpec.describe Transaction do
 
     @ii4 = InvoiceItem.create!(quantity: 5, unit_price: @item4.unit_price, item_id: @item4.id, invoice_id: @invoice4.id)
   end
-  describe 'do' do
-    it 'do' do
 
-      binding.pry
-    end
-
-  end
   describe "Relationships" do
     it {should belong_to :invoice}
     it {should have_many(:merchants).through(:invoice)}


### PR DESCRIPTION
Needed to make a few tweaks after last PR

- spec/features/merchants/show_spec.rb was reverted to a previous version somehow, so I copied the latest version from William's PR over
- set transactions.result to be 0 on failed and 1 on success
- add enum in Transaction model to convert imported result strings to integers
- changed default value for transaction to be 1 to make it easier on our tests, but ultimately I feel like transaction shouldn't really have a default value, right?  Maybe a future refactor.
- modified a couple of view spec tests that were searching for an integer on the page and not a string.  It looks like integer still works but the extra output during our tests was telling us to use a string instead since integer support is getting deprecated soon.