### PR TITLE
Merchant's Top 5 Items by total revenue - User story 12

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -3,4 +3,5 @@ class Item < ApplicationRecord
   has_many :invoice_items
   has_many :invoices, through: :invoice_items
   has_many :customers, through: :invoices
+  has_many :transactions, through: :invoices
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -7,32 +7,31 @@ class Merchant < ApplicationRecord
 
   def self.top5(id)
     Customer
-    .joins(:merchants, :transactions)
-    .where("transactions.result = 1 AND merchants.id = #{id}")
-    .group(:id)
-    .select('first_name, last_name, count(customers) AS transactions_count')
-    .order(transactions_count: :desc)
-    .limit(5)
+      .joins(:merchants, :transactions)
+      .where("transactions.result = 1 AND merchants.id = #{id}")
+      .group(:id)
+      .select('first_name, last_name, count(customers) AS transactions_count')
+      .order(transactions_count: :desc)
+      .limit(5)
   end
 
   def pending_invoices
     Invoice
-    .joins(:merchants)
-    .where("merchants.id = #{id}")
-    .where('invoices.status = 1')
-    .order('invoices.created_at')
-    .distinct
+      .joins(:merchants)
+      .where("merchants.id = #{id}")
+      .where('invoices.status = 1')
+      .order('invoices.created_at')
+      .distinct
   end
 
   def self.total_revenue(invoice_id)
-    Invoice 
-    .joins(:invoice_items)
-    .where("invoice_items.invoice_id = #{invoice_id}")
-    .sum('invoice_items.quantity * invoice_items.unit_price')
-    
+    Invoice
+      .joins(:invoice_items)
+      .where("invoice_items.invoice_id = #{invoice_id}")
+      .sum('invoice_items.quantity * invoice_items.unit_price')
   end
 
-  def self.enabled 
+  def self.enabled
     where(status: 1)
   end
 
@@ -42,14 +41,20 @@ class Merchant < ApplicationRecord
 
   def self.top5_merchants
     joins(invoices: :transactions)
-    .group(:id)
-    .where('transactions.result = 1 AND invoices.status = 1')
-    .select('merchants.*, sum(invoice_items.quantity * invoice_items.unit_price) as total_revenue')
-    .order(total_revenue: :desc)
-    .limit(5)
+      .group(:id)
+      .where('transactions.result = 1 AND invoices.status = 1')
+      .select('merchants.*, sum(invoice_items.quantity * invoice_items.unit_price) as total_revenue')
+      .order(total_revenue: :desc)
+      .limit(5)
   end
 
   def top_5_items
-    require 'pry'; binding.pry
+    items
+      .joins(:invoice_items, :transactions)
+      .where('transactions.result = ?', 1)
+      .select('items.*, sum(invoice_items.quantity * invoice_items.unit_price) as total_revenue')
+      .group(:id)
+      .order(total_revenue: :desc)
+      .first(5)
   end
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -48,4 +48,8 @@ class Merchant < ApplicationRecord
     .order(total_revenue: :desc)
     .limit(5)
   end
+
+  def top_5_items
+    require 'pry'; binding.pry
+  end
 end

--- a/app/views/merchant_items/index.html.erb
+++ b/app/views/merchant_items/index.html.erb
@@ -22,6 +22,6 @@
 
 <section id="top-5-items">
   <% @merchant.top_5_items.each do |item| %>
-    <p><%= link_to item.name, merchant_item_path(@merchant, item) %></p>
+    <p><%= link_to item.name, merchant_item_path(@merchant, item) %> Total Revenue: <%= item.total_revenue %></p>
   <% end %>
 </section>

--- a/app/views/merchant_items/index.html.erb
+++ b/app/views/merchant_items/index.html.erb
@@ -1,24 +1,26 @@
 <p><%= link_to "New Item", new_merchant_item_path(@merchant) %>
 
-<%= "Enabled"%>
+<section id="index">
+  <%= "Enabled"%>
+    <% @merchant.items.each do |item|%>
+      <% if item.status == 1 %>
+      <div id="item-<%= item.id %>">
+      <p><%= link_to item.name, merchant_item_path(@merchant, item) %>
+        <%= button_to  "Disable", "/merchant/#{@merchant.id}/item/#{item.id}", method: :patch, params: { :status => 0 } %>
+      </div>
+      <% end %><p>
+  <% end %>
+
+  <%= "Disabled" %>
   <% @merchant.items.each do |item|%>
-    <% if item.status == 1 %>
+    <% if item.status == 0 %>
     <div id="item-<%= item.id %>">
     <p><%= link_to item.name, merchant_item_path(@merchant, item) %>
-      <%= button_to  "Disable", "/merchant/#{@merchant.id}/item/#{item.id}", method: :patch, params: { :status => 0 } %>
+      <%= button_to  "Enable", "/merchant/#{@merchant.id}/item/#{item.id}", method: :patch, params: { :status => 1 } %>
     </div>
     <% end %><p>
-<% end %>
-
-<%= "Disabled" %>
-<% @merchant.items.each do |item|%>
-  <% if item.status == 0 %>
-  <div id="item-<%= item.id %>">
-  <p><%= link_to item.name, merchant_item_path(@merchant, item) %>
-    <%= button_to  "Enable", "/merchant/#{@merchant.id}/item/#{item.id}", method: :patch, params: { :status => 1 } %>
-  </div>
-  <% end %><p>
-<% end %>
+  <% end %>
+</section>
 
 <section id="top-5-items">
   <% @merchant.top_5_items.each do |item| %>

--- a/app/views/merchant_items/index.html.erb
+++ b/app/views/merchant_items/index.html.erb
@@ -20,3 +20,8 @@
   <% end %><p>
 <% end %>
 
+<section id="top-5-items">
+  <% @merchant.top_5_items.each do |item| %>
+    <p><%= link_to item.name, merchant_item_path(@merchant, item) %></p>
+  <% end %>
+</section>

--- a/spec/features/merchants/invoices/show_spec.rb
+++ b/spec/features/merchants/invoices/show_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe 'Merchant invoice show page' do
     
     expect(page).to have_content(@invoice1.id)
     expect(page).to have_content(@invoice1.status)
-    expect(page).to have_content(@invoice1.created_at.strftime("%A, %B%e, %Y"))
+    expect(page).to have_content(@invoice1.created_at.strftime("%A, %B %e, %Y"))
     expect(page).to have_content(@customer1.first_name)
     expect(page).to have_content(@customer1.last_name)
   end

--- a/spec/features/merchants/items/index_spec.rb
+++ b/spec/features/merchants/items/index_spec.rb
@@ -129,51 +129,18 @@ RSpec.describe 'merchant items index page' do
       Invoice.all.each_with_index do |invoice, _index|
         FactoryBot.create(:transaction, invoice_id: invoice.id, result: 1)
       end
-      top_5 = mariah.top_5_items
 
-      visit merchant_item_index_path(mariah)
+      mariah.top_5_items.each do |item|
+        visit merchant_item_index_path(mariah)
 
-      within('#top-5-items') do
-        expect(page).to have_content(top_5.first.name)
-        expect(page).to have_content(top_5.first.total_revenue)
-        click_link top_5.first.name
-        expect(current_path).to eq(merchant_item_path(mariah.id, top_5.first.id))
-      end
+        within('#top-5-items') do
+          expect(page).to have_content(item.name)
+          expect(page).to have_content(item.total_revenue)
 
-      visit merchant_item_index_path(mariah)
+          click_link item.name
 
-      within('#top-5-items') do
-        expect(page).to have_content(top_5.second.name)
-        expect(page).to have_content(top_5.second.total_revenue)
-        click_link top_5.second.name
-        expect(current_path).to eq(merchant_item_path(mariah.id, top_5.second.id))
-      end
-
-      visit merchant_item_index_path(mariah)
-
-      within('#top-5-items') do
-        expect(page).to have_content(top_5.third.name)
-        expect(page).to have_content(top_5.third.total_revenue)
-        click_link top_5.third.name
-        expect(current_path).to eq(merchant_item_path(mariah.id, top_5.third.id))
-      end
-
-      visit merchant_item_index_path(mariah)
-
-      within('#top-5-items') do
-        expect(page).to have_content(top_5.fourth.name)
-        expect(page).to have_content(top_5.fourth.total_revenue)
-        click_link top_5.fourth.name
-        expect(current_path).to eq(merchant_item_path(mariah.id, top_5.fourth.id))
-      end
-
-      visit merchant_item_index_path(mariah)
-
-      within('#top-5-items') do
-        expect(page).to have_content(top_5.fifth.name)
-        expect(page).to have_content(top_5.fifth.total_revenue)
-        click_link top_5.fifth.name
-        expect(current_path).to eq(merchant_item_path(mariah.id, top_5.fifth.id))
+          expect(current_path).to eq(merchant_item_path(mariah.id, item.id))
+        end
       end
     end
   end

--- a/spec/features/merchants/items/index_spec.rb
+++ b/spec/features/merchants/items/index_spec.rb
@@ -151,7 +151,7 @@ RSpec.describe 'merchant items index page' do
     # Only invoices with at least one successful transaction should count towards revenue
     # Revenue for an invoice should be calculated as the sum of the revenue of all invoice items
     # Revenue for an invoice item should be calculated as the invoice item unit price multiplied by the quantity (do not use the item unit price)
-    it 'shows names of top 5 most popular items ranked by total revenue generated' do
+    it 'shows names of top 5 most popular items ranked by total revenue generated with link to show page' do
       mariah = Merchant.create!(name: 'Mariah Ahmed')
       items = FactoryBot.create_list(:item, 10, merchant_id: mariah.id)
       items.each_with_index do |item, index|
@@ -165,33 +165,52 @@ RSpec.describe 'merchant items index page' do
 
       within('#top-5-items') do
         expect(page).to have_content(top_5.first.name)
+        expect(page).to have_content(top_5.first.total_revenue)
         click_link top_5.first.name
         expect(current_path).to eq(merchant_item_path(mariah.id, top_5.first.id))
       end
       visit merchant_item_index_path(mariah)
       within('#top-5-items') do
         expect(page).to have_content(top_5.second.name)
+        expect(page).to have_content(top_5.second.total_revenue)
         click_link top_5.second.name
         expect(current_path).to eq(merchant_item_path(mariah.id, top_5.second.id))
       end
       visit merchant_item_index_path(mariah)
       within('#top-5-items') do
         expect(page).to have_content(top_5.third.name)
+        expect(page).to have_content(top_5.third.total_revenue)
         click_link top_5.third.name
         expect(current_path).to eq(merchant_item_path(mariah.id, top_5.third.id))
       end
       visit merchant_item_index_path(mariah)
       within('#top-5-items') do
         expect(page).to have_content(top_5.fourth.name)
+        expect(page).to have_content(top_5.fourth.total_revenue)
         click_link top_5.fourth.name
         expect(current_path).to eq(merchant_item_path(mariah.id, top_5.fourth.id))
       end
       visit merchant_item_index_path(mariah)
       within('#top-5-items') do
         expect(page).to have_content(top_5.fifth.name)
+        expect(page).to have_content(top_5.fifth.total_revenue)
         click_link top_5.fifth.name
         expect(current_path).to eq(merchant_item_path(mariah.id, top_5.fifth.id))
       end
     end
+
+    # it 'lists total revenue generated next to each item name' do
+    #   mariah = Merchant.create!(name: 'Mariah Ahmed')
+    #   items = FactoryBot.create_list(:item, 10, merchant_id: mariah.id)
+    #   items.each_with_index do |item, index|
+    #     FactoryBot.create_list(:invoice_item, 2, item_id: item.id, quantity: 1, unit_price: (index * 10))
+    #   end
+    #   Invoice.all.each_with_index do |invoice, _index|
+    #     FactoryBot.create(:transaction, invoice_id: invoice.id, result: 1)
+    #   end
+    #   top_5 = mariah.top_5_items
+
+    #   visit merchant_item_index_path(mariah)
+    # end
   end
 end

--- a/spec/features/merchants/items/index_spec.rb
+++ b/spec/features/merchants/items/index_spec.rb
@@ -128,26 +128,70 @@ RSpec.describe 'merchant items index page' do
   # And I see that each item name links to my merchant item show page for that item
   # And I see the total revenue generated next to each item name
 
-  before :each do
-    FactoryBot.reload
-    @customers = FactoryBot.create_list(:customer_with_invoice, 10)
-    @invoices = Invoice.all
-    FactoryBot.create_list(:transaction, 6, result: 'success', invoice_id: @invoices[0].id)
-    FactoryBot.create_list(:transaction, 5, result: 'success', invoice_id: @invoices[3].id)
-    FactoryBot.create_list(:transaction, 4, result: 'success', invoice_id: @invoices[1].id)
-    FactoryBot.create_list(:transaction, 3, result: 'success', invoice_id: @invoices[4].id)
-    FactoryBot.create_list(:transaction, 2, result: 'success', invoice_id: @invoices[2].id)
-  end
+  # before :each do
+  #   FactoryBot.reload
+  #   @customers = FactoryBot.create_list(:customer_with_invoice, 10)
+  #   @invoices = Invoice.all
+  #   FactoryBot.create_list(:transaction, 6, result: 'success', invoice_id: @invoices[0].id)
+  #   FactoryBot.create_list(:transaction, 5, result: 'success', invoice_id: @invoices[3].id)
+  #   FactoryBot.create_list(:transaction, 4, result: 'success', invoice_id: @invoices[1].id)
+  #   FactoryBot.create_list(:transaction, 3, result: 'success', invoice_id: @invoices[4].id)
+  #   FactoryBot.create_list(:transaction, 2, result: 'success', invoice_id: @invoices[2].id)
+  # end
+  describe '5 most popular items' do
+    #     Merchant Items Index: 5 most popular items
+    # As a merchant
+    # When I visit my items index page
+    # Then I see the names of the top 5 most popular items ranked by total revenue generated
+    # And I see that each item name links to my merchant item show page for that item
+    # And I see the total revenue generated next to each item name
 
-  it 'shows names of top 5 most popular items ranked by total revenue generated' do
-    mariah = Merchant.create!(name: 'Mariah Ahmed')
-    visit merchant_item_index_path(mariah)
-    
- 
     # Notes on Revenue Calculation:
 
     # Only invoices with at least one successful transaction should count towards revenue
     # Revenue for an invoice should be calculated as the sum of the revenue of all invoice items
     # Revenue for an invoice item should be calculated as the invoice item unit price multiplied by the quantity (do not use the item unit price)
+    it 'shows names of top 5 most popular items ranked by total revenue generated' do
+      mariah = Merchant.create!(name: 'Mariah Ahmed')
+      items = FactoryBot.create_list(:item, 10, merchant_id: mariah.id)
+      items.each_with_index do |item, index|
+        FactoryBot.create_list(:invoice_item, 2, item_id: item.id, quantity: 1, unit_price: (index * 10))
+      end
+      Invoice.all.each_with_index do |invoice, _index|
+        FactoryBot.create(:transaction, invoice_id: invoice.id, result: 1)
+      end
+      top_5 = mariah.top_5_items
+      visit merchant_item_index_path(mariah)
+
+      within('#top-5-items') do
+        expect(page).to have_content(top_5.first.name)
+        click_link top_5.first.name
+        expect(current_path).to eq(merchant_item_path(mariah.id, top_5.first.id))
+      end
+      visit merchant_item_index_path(mariah)
+      within('#top-5-items') do
+        expect(page).to have_content(top_5.second.name)
+        click_link top_5.second.name
+        expect(current_path).to eq(merchant_item_path(mariah.id, top_5.second.id))
+      end
+      visit merchant_item_index_path(mariah)
+      within('#top-5-items') do
+        expect(page).to have_content(top_5.third.name)
+        click_link top_5.third.name
+        expect(current_path).to eq(merchant_item_path(mariah.id, top_5.third.id))
+      end
+      visit merchant_item_index_path(mariah)
+      within('#top-5-items') do
+        expect(page).to have_content(top_5.fourth.name)
+        click_link top_5.fourth.name
+        expect(current_path).to eq(merchant_item_path(mariah.id, top_5.fourth.id))
+      end
+      visit merchant_item_index_path(mariah)
+      within('#top-5-items') do
+        expect(page).to have_content(top_5.fifth.name)
+        click_link top_5.fifth.name
+        expect(current_path).to eq(merchant_item_path(mariah.id, top_5.fifth.id))
+      end
+    end
   end
 end

--- a/spec/features/merchants/items/index_spec.rb
+++ b/spec/features/merchants/items/index_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe 'merchant items index page' do
       end
 
       pen.reload
-      
+
       expect(page).to have_current_path(merchant_item_index_path(mariah))
       expect(pen.status).to eq(1)
       expect(page).to have_button('Disable')
@@ -99,29 +99,55 @@ RSpec.describe 'merchant items index page' do
       expect(gloves.status).to eq(0)
     end
   end
-  
-  describe "story 10" do
+
+  describe 'story 10' do
     #     As a merchant,
     # When I visit my merchant items index page
     # Then I see two sections, one for "Enabled Items" and one for "Disabled Items"
     # And I see that each Item is listed in the appropriate section
-    
+
     it 'has has a section for enabled and one for disabled items' do
-      mariah = Merchant.create!(name: "Mariah Ahmed")
-      terry = Merchant.create!(name: "Terry Peeples")
-      
-      pen = mariah.items.create!(name: "pen", description: "writes stuff", unit_price: 33)
-      marker = mariah.items.create!(name: "marker", description: "writes stuff", unit_price: 23)
-      pencil = mariah.items.create!(name: "pencil", description: "writes stuff", unit_price: 13)
-      
-      socks = terry.items.create!(name: "socks", description: "keeps feet warm", unit_price: 8)
-      shoes = terry.items.create!(name: "shoes", description: "provides arch support", unit_price: 68)
-      
+      mariah = Merchant.create!(name: 'Mariah Ahmed')
+      terry = Merchant.create!(name: 'Terry Peeples')
+
+      pen = mariah.items.create!(name: 'pen', description: 'writes stuff', unit_price: 33)
+      marker = mariah.items.create!(name: 'marker', description: 'writes stuff', unit_price: 23)
+      pencil = mariah.items.create!(name: 'pencil', description: 'writes stuff', unit_price: 13)
+
+      socks = terry.items.create!(name: 'socks', description: 'keeps feet warm', unit_price: 8)
+      shoes = terry.items.create!(name: 'shoes', description: 'provides arch support', unit_price: 68)
+
       visit merchant_item_index_path(mariah)
-      
-      
-      expect(page).to have_content("Enabled")
-      expect(page).to have_content("Disabled")
+
+      expect(page).to have_content('Enabled')
+      expect(page).to have_content('Disabled')
     end
+  end
+
+  # Then I see the names of the top 5 most popular items ranked by total revenue generated
+  # And I see that each item name links to my merchant item show page for that item
+  # And I see the total revenue generated next to each item name
+
+  before :each do
+    FactoryBot.reload
+    @customers = FactoryBot.create_list(:customer_with_invoice, 10)
+    @invoices = Invoice.all
+    FactoryBot.create_list(:transaction, 6, result: 'success', invoice_id: @invoices[0].id)
+    FactoryBot.create_list(:transaction, 5, result: 'success', invoice_id: @invoices[3].id)
+    FactoryBot.create_list(:transaction, 4, result: 'success', invoice_id: @invoices[1].id)
+    FactoryBot.create_list(:transaction, 3, result: 'success', invoice_id: @invoices[4].id)
+    FactoryBot.create_list(:transaction, 2, result: 'success', invoice_id: @invoices[2].id)
+  end
+
+  it 'shows names of top 5 most popular items ranked by total revenue generated' do
+    mariah = Merchant.create!(name: 'Mariah Ahmed')
+    visit merchant_item_index_path(mariah)
+    
+ 
+    # Notes on Revenue Calculation:
+
+    # Only invoices with at least one successful transaction should count towards revenue
+    # Revenue for an invoice should be calculated as the sum of the revenue of all invoice items
+    # Revenue for an invoice item should be calculated as the invoice item unit price multiplied by the quantity (do not use the item unit price)
   end
 end

--- a/spec/features/merchants/items/index_spec.rb
+++ b/spec/features/merchants/items/index_spec.rb
@@ -101,11 +101,6 @@ RSpec.describe 'merchant items index page' do
   end
 
   describe 'story 10' do
-    #     As a merchant,
-    # When I visit my merchant items index page
-    # Then I see two sections, one for "Enabled Items" and one for "Disabled Items"
-    # And I see that each Item is listed in the appropriate section
-
     it 'has has a section for enabled and one for disabled items' do
       mariah = Merchant.create!(name: 'Mariah Ahmed')
       terry = Merchant.create!(name: 'Terry Peeples')
@@ -124,34 +119,8 @@ RSpec.describe 'merchant items index page' do
     end
   end
 
-  # Then I see the names of the top 5 most popular items ranked by total revenue generated
-  # And I see that each item name links to my merchant item show page for that item
-  # And I see the total revenue generated next to each item name
-
-  # before :each do
-  #   FactoryBot.reload
-  #   @customers = FactoryBot.create_list(:customer_with_invoice, 10)
-  #   @invoices = Invoice.all
-  #   FactoryBot.create_list(:transaction, 6, result: 'success', invoice_id: @invoices[0].id)
-  #   FactoryBot.create_list(:transaction, 5, result: 'success', invoice_id: @invoices[3].id)
-  #   FactoryBot.create_list(:transaction, 4, result: 'success', invoice_id: @invoices[1].id)
-  #   FactoryBot.create_list(:transaction, 3, result: 'success', invoice_id: @invoices[4].id)
-  #   FactoryBot.create_list(:transaction, 2, result: 'success', invoice_id: @invoices[2].id)
-  # end
   describe '5 most popular items' do
-    #     Merchant Items Index: 5 most popular items
-    # As a merchant
-    # When I visit my items index page
-    # Then I see the names of the top 5 most popular items ranked by total revenue generated
-    # And I see that each item name links to my merchant item show page for that item
-    # And I see the total revenue generated next to each item name
-
-    # Notes on Revenue Calculation:
-
-    # Only invoices with at least one successful transaction should count towards revenue
-    # Revenue for an invoice should be calculated as the sum of the revenue of all invoice items
-    # Revenue for an invoice item should be calculated as the invoice item unit price multiplied by the quantity (do not use the item unit price)
-    it 'shows names of top 5 most popular items ranked by total revenue generated with link to show page' do
+    it 'lists top 5 most popular items by total revenue with link to show page' do
       mariah = Merchant.create!(name: 'Mariah Ahmed')
       items = FactoryBot.create_list(:item, 10, merchant_id: mariah.id)
       items.each_with_index do |item, index|
@@ -161,6 +130,7 @@ RSpec.describe 'merchant items index page' do
         FactoryBot.create(:transaction, invoice_id: invoice.id, result: 1)
       end
       top_5 = mariah.top_5_items
+
       visit merchant_item_index_path(mariah)
 
       within('#top-5-items') do
@@ -169,28 +139,36 @@ RSpec.describe 'merchant items index page' do
         click_link top_5.first.name
         expect(current_path).to eq(merchant_item_path(mariah.id, top_5.first.id))
       end
+
       visit merchant_item_index_path(mariah)
+
       within('#top-5-items') do
         expect(page).to have_content(top_5.second.name)
         expect(page).to have_content(top_5.second.total_revenue)
         click_link top_5.second.name
         expect(current_path).to eq(merchant_item_path(mariah.id, top_5.second.id))
       end
+
       visit merchant_item_index_path(mariah)
+
       within('#top-5-items') do
         expect(page).to have_content(top_5.third.name)
         expect(page).to have_content(top_5.third.total_revenue)
         click_link top_5.third.name
         expect(current_path).to eq(merchant_item_path(mariah.id, top_5.third.id))
       end
+
       visit merchant_item_index_path(mariah)
+
       within('#top-5-items') do
         expect(page).to have_content(top_5.fourth.name)
         expect(page).to have_content(top_5.fourth.total_revenue)
         click_link top_5.fourth.name
         expect(current_path).to eq(merchant_item_path(mariah.id, top_5.fourth.id))
       end
+
       visit merchant_item_index_path(mariah)
+
       within('#top-5-items') do
         expect(page).to have_content(top_5.fifth.name)
         expect(page).to have_content(top_5.fifth.total_revenue)
@@ -198,19 +176,5 @@ RSpec.describe 'merchant items index page' do
         expect(current_path).to eq(merchant_item_path(mariah.id, top_5.fifth.id))
       end
     end
-
-    # it 'lists total revenue generated next to each item name' do
-    #   mariah = Merchant.create!(name: 'Mariah Ahmed')
-    #   items = FactoryBot.create_list(:item, 10, merchant_id: mariah.id)
-    #   items.each_with_index do |item, index|
-    #     FactoryBot.create_list(:invoice_item, 2, item_id: item.id, quantity: 1, unit_price: (index * 10))
-    #   end
-    #   Invoice.all.each_with_index do |invoice, _index|
-    #     FactoryBot.create(:transaction, invoice_id: invoice.id, result: 1)
-    #   end
-    #   top_5 = mariah.top_5_items
-
-    #   visit merchant_item_index_path(mariah)
-    # end
   end
 end

--- a/spec/features/merchants/items/show_spec.rb
+++ b/spec/features/merchants/items/show_spec.rb
@@ -43,8 +43,10 @@ RSpec.describe "Merchant items show page" do
 # - Current Selling Price
     it 'can click on the names of items and take me to the merchant show page' do
       visit merchant_item_index_path(@merchant1)
-      
-      click_on('Chips')
+
+      within("#index") do
+        click_on('Chips')
+      end
 
       expect(page).to have_current_path("/merchant/#{@merchant1.id}/item/#{@item1.id}")
     end

--- a/spec/features/merchants/items/show_spec.rb
+++ b/spec/features/merchants/items/show_spec.rb
@@ -43,6 +43,7 @@ RSpec.describe "Merchant items show page" do
 # - Current Selling Price
     it 'can click on the names of items and take me to the merchant show page' do
       visit merchant_item_index_path(@merchant1)
+      
       click_on('Chips')
 
       expect(page).to have_current_path("/merchant/#{@merchant1.id}/item/#{@item1.id}")

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -6,5 +6,6 @@ RSpec.describe Item do
     it {should have_many :invoice_items} 
     it {should have_many(:invoices).through(:invoice_items)} 
     it {should have_many(:customers).through(:invoices)}
+    it {should have_many(:transactions).through(:invoices)}
   end
 end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -256,6 +256,8 @@ RSpec.describe Merchant do
           end
 
           expect(merchant.top_5_items).to eq(items.last(5).reverse)
+          # binding.pry
+          # expect(merchant.top_5_items.first.total_revenue).to eq(items)
         end
       end
     end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -36,13 +36,13 @@ RSpec.describe Merchant do
 
     @ii4 = InvoiceItem.create!(quantity: 5, unit_price: @item4.unit_price, item_id: @item4.id, invoice_id: @invoice4.id)
   end
-   
-  describe "Relationships" do
-    it {should have_many :items} 
-    it {should have_many(:invoice_items).through(:items)}
-    it {should have_many(:invoices).through(:invoice_items)}
-    it {should have_many(:customers).through(:invoices)}
-    it {should have_many(:transactions).through(:invoices)}
+
+  describe 'Relationships' do
+    it { should have_many :items }
+    it { should have_many(:invoice_items).through(:items) }
+    it { should have_many(:invoices).through(:invoice_items) }
+    it { should have_many(:customers).through(:invoices) }
+    it { should have_many(:transactions).through(:invoices) }
   end
 
   describe '#top5' do
@@ -72,9 +72,11 @@ RSpec.describe Merchant do
 
       item8 = Item.create!(name: 'fak121212e', description: 'T121212ing', unit_price: 30, merchant_id: @merchant1.id)
       invoice8 = Invoice.create!(status: 1, customer_id: @customer2.id)
-      transaction8 = Transaction.create!(credit_card_number: '121987654', credit_card_expiration_date: '02/07', invoice_id: invoice8.id)
-      ii8 = InvoiceItem.create!(quantity: 5, unit_price: item8.unit_price, item_id: item8.id, invoice_id: invoice8.id)    
-      
+      transaction8 = Transaction.create!(credit_card_number: '121987654', credit_card_expiration_date: '02/07',
+                                         invoice_id: invoice8.id)
+      ii8 = InvoiceItem.create!(quantity: 5, unit_price: item8.unit_price, item_id: item8.id,
+                                invoice_id: invoice8.id)
+
       item9 = Item.create!(name: 'fak121212e', description: 'T121212ing', unit_price: 30, merchant_id: @merchant1.id)
       invoice9 = Invoice.create!(status: 1, customer_id: customer3.id)
       transaction9 = Transaction.create!(credit_card_number: '121987654', credit_card_expiration_date: '02/07',
@@ -90,9 +92,11 @@ RSpec.describe Merchant do
 
       item11 = Item.create!(name: 'fak121212e', description: 'T121212ing', unit_price: 30, merchant_id: @merchant1.id)
       invoice11 = Invoice.create!(status: 1, customer_id: customer3.id)
-      transaction11 = Transaction.create!(credit_card_number: '121987654', credit_card_expiration_date: '02/07', invoice_id: invoice11.id)
-      ii11 = InvoiceItem.create!(quantity: 5, unit_price: item11.unit_price, item_id: item11.id, invoice_id: invoice11.id)
-      
+      transaction11 = Transaction.create!(credit_card_number: '121987654', credit_card_expiration_date: '02/07',
+                                          invoice_id: invoice11.id)
+      ii11 = InvoiceItem.create!(quantity: 5, unit_price: item11.unit_price, item_id: item11.id,
+                                 invoice_id: invoice11.id)
+
       item12 = Item.create!(name: 'fak121212e', description: 'T121212ing', unit_price: 30, merchant_id: @merchant1.id)
       invoice12 = Invoice.create!(status: 1, customer_id: customer4.id)
       transaction12 = Transaction.create!(credit_card_number: '121987654', credit_card_expiration_date: '02/07',
@@ -137,14 +141,18 @@ RSpec.describe Merchant do
 
       item18 = Item.create!(name: 'fak121212e', description: 'T121212ing', unit_price: 30, merchant_id: @merchant1.id)
       invoice18 = Invoice.create!(status: 1, customer_id: customer6.id)
-      transaction18 = Transaction.create!(credit_card_number: '121987654', credit_card_expiration_date: '02/07', invoice_id: invoice18.id)
-      ii18 = InvoiceItem.create!(quantity: 5, unit_price: item18.unit_price, item_id: item18.id, invoice_id: invoice18.id)
-      
+      transaction18 = Transaction.create!(credit_card_number: '121987654', credit_card_expiration_date: '02/07',
+                                          invoice_id: invoice18.id)
+      ii18 = InvoiceItem.create!(quantity: 5, unit_price: item18.unit_price, item_id: item18.id,
+                                 invoice_id: invoice18.id)
+
       item19 = Item.create!(name: 'fak121212e', description: 'T121212ing', unit_price: 30, merchant_id: @merchant1.id)
       invoice19 = Invoice.create!(status: 1, customer_id: @customer1.id)
-      transaction19 = Transaction.create!(credit_card_number: '121987654', credit_card_expiration_date: '02/07', invoice_id: invoice19.id)
-      ii19 = InvoiceItem.create!(quantity: 5, unit_price: item19.unit_price, item_id: item19.id, invoice_id: invoice19.id)
-  
+      transaction19 = Transaction.create!(credit_card_number: '121987654', credit_card_expiration_date: '02/07',
+                                          invoice_id: invoice19.id)
+      ii19 = InvoiceItem.create!(quantity: 5, unit_price: item19.unit_price, item_id: item19.id,
+                                 invoice_id: invoice19.id)
+
       item20 = Item.create!(name: 'fak121212e', description: 'T121212ing', unit_price: 30, merchant_id: @merchant1.id)
       invoice20 = Invoice.create!(status: 1, customer_id: customer3.id)
       transaction20 = Transaction.create!(credit_card_number: '121987654', credit_card_expiration_date: '02/07',
@@ -160,52 +168,52 @@ RSpec.describe Merchant do
     end
   end
 
-    describe 'instance methods' do
-      describe '#pending_invoices' do
-        it 'returns invoices with status pending for a merchant' do
-          merchant1 = Merchant.create!(name: 'Rays Hand Made Jewlery')
-          item1 = Item.create!(name: 'Chips', description: 'Ring', unit_price: 20, merchant_id: merchant1.id)
-          customer = Customer.create!(first_name: 'Kyle', last_name: 'Ledin')
-          invoice1 = Invoice.create!(status: 1, customer_id: customer.id)
-          ii1 = InvoiceItem.create!(quantity: 5, unit_price: item1.unit_price, item_id: item1.id,
-                                    invoice_id: invoice1.id)
+  describe 'instance methods' do
+    describe '#pending_invoices' do
+      it 'returns invoices with status pending for a merchant' do
+        merchant1 = Merchant.create!(name: 'Rays Hand Made Jewlery')
+        item1 = Item.create!(name: 'Chips', description: 'Ring', unit_price: 20, merchant_id: merchant1.id)
+        customer = Customer.create!(first_name: 'Kyle', last_name: 'Ledin')
+        invoice1 = Invoice.create!(status: 1, customer_id: customer.id)
+        ii1 = InvoiceItem.create!(quantity: 5, unit_price: item1.unit_price, item_id: item1.id,
+                                  invoice_id: invoice1.id)
 
-          expect(merchant1.pending_invoices).to eq([invoice1])
+        expect(merchant1.pending_invoices).to eq([invoice1])
 
-          invoice2 = Invoice.create!(status: 1, customer_id: customer.id)
-          ii2 = InvoiceItem.create!(quantity: 5, unit_price: item1.unit_price, item_id: item1.id,
-                                    invoice_id: invoice2.id)
+        invoice2 = Invoice.create!(status: 1, customer_id: customer.id)
+        ii2 = InvoiceItem.create!(quantity: 5, unit_price: item1.unit_price, item_id: item1.id,
+                                  invoice_id: invoice2.id)
 
-          expect(merchant1.pending_invoices).to eq([invoice1, invoice2])
-        end
+        expect(merchant1.pending_invoices).to eq([invoice1, invoice2])
+      end
 
-        it 'does not return pending invoices for other merchants' do
-          merchant1 = Merchant.create!(name: 'Rays Hand Made Jewlery')
-          item1 = Item.create!(name: 'Chips', description: 'Ring', unit_price: 20, merchant_id: merchant1.id)
-          customer = Customer.create!(first_name: 'Kyle', last_name: 'Ledin')
-          invoice1 = Invoice.create!(status: 1, customer_id: customer.id)
-          ii1 = InvoiceItem.create!(quantity: 5, unit_price: item1.unit_price, item_id: item1.id,
-                                    invoice_id: invoice1.id)
-          invoice2 = Invoice.create!(status: 1, customer_id: customer.id)
-          ii2 = InvoiceItem.create!(quantity: 5, unit_price: item1.unit_price, item_id: item1.id,
-                                    invoice_id: invoice2.id)
-          merchant2 = Merchant.create!(name: 'Pizza Man')
-          item2 = Item.create!(name: 'Chips', description: 'Ring', unit_price: 20, merchant_id: merchant2.id)
-          invoice3 = Invoice.create!(status: 1, customer_id: customer.id)
-          ii3 = InvoiceItem.create!(quantity: 5, unit_price: item1.unit_price, item_id: item2.id,
-                                    invoice_id: invoice3.id)
+      it 'does not return pending invoices for other merchants' do
+        merchant1 = Merchant.create!(name: 'Rays Hand Made Jewlery')
+        item1 = Item.create!(name: 'Chips', description: 'Ring', unit_price: 20, merchant_id: merchant1.id)
+        customer = Customer.create!(first_name: 'Kyle', last_name: 'Ledin')
+        invoice1 = Invoice.create!(status: 1, customer_id: customer.id)
+        ii1 = InvoiceItem.create!(quantity: 5, unit_price: item1.unit_price, item_id: item1.id,
+                                  invoice_id: invoice1.id)
+        invoice2 = Invoice.create!(status: 1, customer_id: customer.id)
+        ii2 = InvoiceItem.create!(quantity: 5, unit_price: item1.unit_price, item_id: item1.id,
+                                  invoice_id: invoice2.id)
+        merchant2 = Merchant.create!(name: 'Pizza Man')
+        item2 = Item.create!(name: 'Chips', description: 'Ring', unit_price: 20, merchant_id: merchant2.id)
+        invoice3 = Invoice.create!(status: 1, customer_id: customer.id)
+        ii3 = InvoiceItem.create!(quantity: 5, unit_price: item1.unit_price, item_id: item2.id,
+                                  invoice_id: invoice3.id)
 
-          expect(merchant1.pending_invoices).to eq([invoice1, invoice2])
-          expect(merchant2.pending_invoices).to eq([invoice3])
-        end
+        expect(merchant1.pending_invoices).to eq([invoice1, invoice2])
+        expect(merchant2.pending_invoices).to eq([invoice3])
+      end
 
-        it 'does not return invoices with statuses other than pending' do
-          merchant1 = Merchant.create!(name: 'Rays Hand Made Jewlery')
-          item1 = Item.create!(name: 'Chips', description: 'Ring', unit_price: 20, merchant_id: merchant1.id)
-          customer = Customer.create!(first_name: 'Kyle', last_name: 'Ledin')
-          invoice1 = Invoice.create!(status: 0, customer_id: customer.id)
-          ii1 = InvoiceItem.create!(quantity: 5, unit_price: item1.unit_price, item_id: item1.id,
-                                    invoice_id: invoice1.id)
+      it 'does not return invoices with statuses other than pending' do
+        merchant1 = Merchant.create!(name: 'Rays Hand Made Jewlery')
+        item1 = Item.create!(name: 'Chips', description: 'Ring', unit_price: 20, merchant_id: merchant1.id)
+        customer = Customer.create!(first_name: 'Kyle', last_name: 'Ledin')
+        invoice1 = Invoice.create!(status: 0, customer_id: customer.id)
+        ii1 = InvoiceItem.create!(quantity: 5, unit_price: item1.unit_price, item_id: item1.id,
+                                  invoice_id: invoice1.id)
 
         expect(merchant1.pending_invoices).to eq([])
       end
@@ -215,16 +223,40 @@ RSpec.describe Merchant do
         item1 = Item.create!(name: 'Chips', description: 'Ring', unit_price: 20, merchant_id: merchant1.id)
         customer = Customer.create!(first_name: 'Kyle', last_name: 'Ledin')
         invoice1 = Invoice.create!(status: 1, customer_id: customer.id)
-        ii1 = InvoiceItem.create!(quantity: 5, unit_price: item1.unit_price, item_id: item1.id, invoice_id: invoice1.id)
-        invoice2 = Invoice.create!(status: 1, customer_id: customer.id, created_at: Time.now-5.days)
-        ii2 = InvoiceItem.create!(quantity: 5, unit_price: item1.unit_price, item_id: item1.id, invoice_id: invoice2.id)
-        invoice3 = Invoice.create!(status: 1, customer_id: customer.id, created_at: Time.now-15.days)
-        ii3 = InvoiceItem.create!(quantity: 5, unit_price: item1.unit_price, item_id: item1.id, invoice_id: invoice3.id)
-        
+        ii1 = InvoiceItem.create!(quantity: 5, unit_price: item1.unit_price, item_id: item1.id,
+                                  invoice_id: invoice1.id)
+        invoice2 = Invoice.create!(status: 1, customer_id: customer.id, created_at: Time.now - 5.days)
+        ii2 = InvoiceItem.create!(quantity: 5, unit_price: item1.unit_price, item_id: item1.id,
+                                  invoice_id: invoice2.id)
+        invoice3 = Invoice.create!(status: 1, customer_id: customer.id, created_at: Time.now - 15.days)
+        ii3 = InvoiceItem.create!(quantity: 5, unit_price: item1.unit_price, item_id: item1.id,
+                                  invoice_id: invoice3.id)
+
         expect(merchant1.pending_invoices).to eq([invoice3, invoice2, invoice1])
-        invoice4 = Invoice.create!(status: 1, customer_id: customer.id, created_at: Time.now-4.days)
-        ii = InvoiceItem.create!(quantity: 5, unit_price: item1.unit_price, item_id: item1.id, invoice_id: invoice4.id)
+        invoice4 = Invoice.create!(status: 1, customer_id: customer.id, created_at: Time.now - 4.days)
+        ii = InvoiceItem.create!(quantity: 5, unit_price: item1.unit_price, item_id: item1.id,
+                                 invoice_id: invoice4.id)
         expect(merchant1.pending_invoices).to eq([invoice3, invoice2, invoice4, invoice1])
+      end
+      describe 'top_5_items' do
+        it 'returns top 5 most popular items ranked by total revenue generated' do
+          # Notes on Revenue Calculation:
+
+          # Only invoices with at least one successful transaction should count towards revenue
+          # Revenue for an invoice should be calculated as the sum of the revenue of all invoice items
+          # Revenue for an invoice item should be calculated as the invoice item unit price multiplied by the quantity (do not use the item unit price)
+
+          merchant = FactoryBot.create(:merchant)
+          items = FactoryBot.create_list(:item, 10, merchant_id: merchant.id)
+          items.each_with_index do |item, index|
+            FactoryBot.create_list(:invoice_item, 2, item_id: item.id, unit_price: (index * 10))
+          end
+          Invoice.all.each_with_index do |invoice, _index|
+            FactoryBot.create(:transaction, invoice_id: invoice.id, result: 1)
+          end
+
+          expect(merchant.top_5_items).to eq(items.last(5))
+        end
       end
     end
   end
@@ -237,102 +269,123 @@ RSpec.describe Merchant do
   end
   describe '#top5_merchants' do
     it 'sorts top 5 merchants by total revenue' do
-      merchant3 = Merchant.create!(name: 'Third Merchant') 
-      merchant4 = Merchant.create!(name: 'Fourth Merchant') 
-      merchant5 = Merchant.create!(name: 'Fifth Merchant') 
-      merchant6 = Merchant.create!(name: 'Sixth Merchant') 
-  
+      merchant3 = Merchant.create!(name: 'Third Merchant')
+      merchant4 = Merchant.create!(name: 'Fourth Merchant')
+      merchant5 = Merchant.create!(name: 'Fifth Merchant')
+      merchant6 = Merchant.create!(name: 'Sixth Merchant')
+
       customer3 = Customer.create!(first_name: 'Third', last_name: 'Guy')
       customer4 = Customer.create!(first_name: 'Fourth', last_name: 'Guy')
       customer5 = Customer.create!(first_name: 'Fifth', last_name: 'Guy')
       customer6 = Customer.create!(first_name: 'Sixth', last_name: 'Guy')
-  
+
       item5 = Item.create!(name: 'fak121212e', description: 'T121212ing', unit_price: 30, merchant_id: @merchant1.id)
       invoice5 = Invoice.create!(status: 1, customer_id: @customer1.id)
-      transaction5 = Transaction.create!(credit_card_number: '121987654', credit_card_expiration_date: '02/07', invoice_id: invoice5.id)
+      transaction5 = Transaction.create!(credit_card_number: '121987654', credit_card_expiration_date: '02/07',
+                                         invoice_id: invoice5.id)
       ii5 = InvoiceItem.create!(quantity: 5, unit_price: item5.unit_price, item_id: item5.id, invoice_id: invoice5.id)
-  
+
       item6 = Item.create!(name: 'fak121212e', description: 'T121212ing', unit_price: 30, merchant_id: @merchant1.id)
       invoice6 = Invoice.create!(status: 1, customer_id: @customer2.id)
-      transaction6 = Transaction.create!(credit_card_number: '121987654', credit_card_expiration_date: '02/07', invoice_id: invoice6.id)
+      transaction6 = Transaction.create!(credit_card_number: '121987654', credit_card_expiration_date: '02/07',
+                                         invoice_id: invoice6.id)
       ii6 = InvoiceItem.create!(quantity: 5, unit_price: item6.unit_price, item_id: item6.id, invoice_id: invoice6.id)
-  
+
       item7 = Item.create!(name: 'fak121212e', description: 'T121212ing', unit_price: 30, merchant_id: @merchant1.id)
       invoice7 = Invoice.create!(status: 1, customer_id: @customer1.id)
-      transaction7 = Transaction.create!(credit_card_number: '121987654', credit_card_expiration_date: '02/07', invoice_id: invoice7.id)
+      transaction7 = Transaction.create!(credit_card_number: '121987654', credit_card_expiration_date: '02/07',
+                                         invoice_id: invoice7.id)
       ii7 = InvoiceItem.create!(quantity: 5, unit_price: item7.unit_price, item_id: item7.id, invoice_id: invoice7.id)
-  
+
       item8 = Item.create!(name: 'fak121212e', description: 'T121212ing', unit_price: 30, merchant_id: @merchant2.id)
       invoice8 = Invoice.create!(status: 1, customer_id: @customer2.id)
-      transaction8 = Transaction.create!(credit_card_number: '121987654', credit_card_expiration_date: '02/07', invoice_id: invoice8.id)
-      ii8 = InvoiceItem.create!(quantity: 5, unit_price: item8.unit_price, item_id: item8.id, invoice_id: invoice8.id)    
-      
-  
-      
+      transaction8 = Transaction.create!(credit_card_number: '121987654', credit_card_expiration_date: '02/07',
+                                         invoice_id: invoice8.id)
+      ii8 = InvoiceItem.create!(quantity: 5, unit_price: item8.unit_price, item_id: item8.id,
+                                invoice_id: invoice8.id)
+
       item9 = Item.create!(name: 'fak121212e', description: 'T121212ing', unit_price: 30, merchant_id: @merchant2.id)
       invoice9 = Invoice.create!(status: 1, customer_id: customer3.id)
-      transaction9 = Transaction.create!(credit_card_number: '121987654', credit_card_expiration_date: '02/07', invoice_id: invoice9.id)
+      transaction9 = Transaction.create!(credit_card_number: '121987654', credit_card_expiration_date: '02/07',
+                                         invoice_id: invoice9.id)
       ii9 = InvoiceItem.create!(quantity: 5, unit_price: item9.unit_price, item_id: item9.id, invoice_id: invoice9.id)
-  
+
       item10 = Item.create!(name: 'fak121212e', description: 'T121212ing', unit_price: 30, merchant_id: @merchant2.id)
       invoice10 = Invoice.create!(status: 1, customer_id: customer3.id)
-      transaction10 = Transaction.create!(credit_card_number: '121987654', credit_card_expiration_date: '02/07', invoice_id: invoice10.id)
-      ii10 = InvoiceItem.create!(quantity: 5, unit_price: item10.unit_price, item_id: item10.id, invoice_id: invoice10.id)
-      
+      transaction10 = Transaction.create!(credit_card_number: '121987654', credit_card_expiration_date: '02/07',
+                                          invoice_id: invoice10.id)
+      ii10 = InvoiceItem.create!(quantity: 5, unit_price: item10.unit_price, item_id: item10.id,
+                                 invoice_id: invoice10.id)
+
       item11 = Item.create!(name: 'fak121212e', description: 'T121212ing', unit_price: 30, merchant_id: @merchant2.id)
       invoice11 = Invoice.create!(status: 1, customer_id: customer3.id)
-      transaction11 = Transaction.create!(credit_card_number: '121987654', credit_card_expiration_date: '02/07', invoice_id: invoice11.id)
-      ii11 = InvoiceItem.create!(quantity: 5, unit_price: item11.unit_price, item_id: item11.id, invoice_id: invoice11.id)
-      
-  
-  
+      transaction11 = Transaction.create!(credit_card_number: '121987654', credit_card_expiration_date: '02/07',
+                                          invoice_id: invoice11.id)
+      ii11 = InvoiceItem.create!(quantity: 5, unit_price: item11.unit_price, item_id: item11.id,
+                                 invoice_id: invoice11.id)
+
       item12 = Item.create!(name: 'fak121212e', description: 'T121212ing', unit_price: 30, merchant_id: merchant3.id)
       invoice12 = Invoice.create!(status: 1, customer_id: customer4.id)
-      transaction12 = Transaction.create!(credit_card_number: '121987654', credit_card_expiration_date: '02/07', invoice_id: invoice12.id)
-      ii12 = InvoiceItem.create!(quantity: 5, unit_price: item12.unit_price, item_id: item12.id, invoice_id: invoice12.id)
-  
+      transaction12 = Transaction.create!(credit_card_number: '121987654', credit_card_expiration_date: '02/07',
+                                          invoice_id: invoice12.id)
+      ii12 = InvoiceItem.create!(quantity: 5, unit_price: item12.unit_price, item_id: item12.id,
+                                 invoice_id: invoice12.id)
+
       item13 = Item.create!(name: 'fak121212e', description: 'T121212ing', unit_price: 30, merchant_id: merchant3.id)
       invoice13 = Invoice.create!(status: 1, customer_id: customer4.id)
-      transaction13 = Transaction.create!(credit_card_number: '121987654', credit_card_expiration_date: '02/07', invoice_id: invoice13.id)
-      ii13 = InvoiceItem.create!(quantity: 5, unit_price: item13.unit_price, item_id: item13.id, invoice_id: invoice13.id)
-      
+      transaction13 = Transaction.create!(credit_card_number: '121987654', credit_card_expiration_date: '02/07',
+                                          invoice_id: invoice13.id)
+      ii13 = InvoiceItem.create!(quantity: 5, unit_price: item13.unit_price, item_id: item13.id,
+                                 invoice_id: invoice13.id)
+
       item14 = Item.create!(name: 'fak121212e', description: 'T121212ing', unit_price: 30, merchant_id: merchant3.id)
       invoice14 = Invoice.create!(status: 1, customer_id: customer4.id)
-      transaction14 = Transaction.create!(credit_card_number: '121987654', credit_card_expiration_date: '02/07', invoice_id: invoice14.id)
-      ii14 = InvoiceItem.create!(quantity: 5, unit_price: item14.unit_price, item_id: item14.id, invoice_id: invoice14.id)
-      
+      transaction14 = Transaction.create!(credit_card_number: '121987654', credit_card_expiration_date: '02/07',
+                                          invoice_id: invoice14.id)
+      ii14 = InvoiceItem.create!(quantity: 5, unit_price: item14.unit_price, item_id: item14.id,
+                                 invoice_id: invoice14.id)
+
       item15 = Item.create!(name: 'fak121212e', description: 'T121212ing', unit_price: 30, merchant_id: merchant3.id)
       invoice15 = Invoice.create!(status: 1, customer_id: @customer2.id)
-      transaction15 = Transaction.create!(credit_card_number: '121987654', credit_card_expiration_date: '02/07', invoice_id: invoice15.id)
-      ii15 = InvoiceItem.create!(quantity: 5, unit_price: item15.unit_price, item_id: item15.id, invoice_id: invoice15.id)
-      
+      transaction15 = Transaction.create!(credit_card_number: '121987654', credit_card_expiration_date: '02/07',
+                                          invoice_id: invoice15.id)
+      ii15 = InvoiceItem.create!(quantity: 5, unit_price: item15.unit_price, item_id: item15.id,
+                                 invoice_id: invoice15.id)
+
       item16 = Item.create!(name: 'fak121212e', description: 'T121212ing', unit_price: 30, merchant_id: merchant4.id)
       invoice16 = Invoice.create!(status: 1, customer_id: customer5.id)
-      transaction16 = Transaction.create!(credit_card_number: '121987654', credit_card_expiration_date: '02/07', invoice_id: invoice16.id)
-      ii16 = InvoiceItem.create!(quantity: 5, unit_price: item16.unit_price, item_id: item16.id, invoice_id: invoice16.id)
-  
+      transaction16 = Transaction.create!(credit_card_number: '121987654', credit_card_expiration_date: '02/07',
+                                          invoice_id: invoice16.id)
+      ii16 = InvoiceItem.create!(quantity: 5, unit_price: item16.unit_price, item_id: item16.id,
+                                 invoice_id: invoice16.id)
+
       item17 = Item.create!(name: 'fak121212e', description: 'T121212ing', unit_price: 30, merchant_id: merchant4.id)
       invoice17 = Invoice.create!(status: 1, customer_id: customer5.id)
-      transaction17 = Transaction.create!(credit_card_number: '121987654', credit_card_expiration_date: '02/07', invoice_id: invoice17.id)
-      ii17 = InvoiceItem.create!(quantity: 5, unit_price: item17.unit_price, item_id: item17.id, invoice_id: invoice17.id)
-  
+      transaction17 = Transaction.create!(credit_card_number: '121987654', credit_card_expiration_date: '02/07',
+                                          invoice_id: invoice17.id)
+      ii17 = InvoiceItem.create!(quantity: 5, unit_price: item17.unit_price, item_id: item17.id,
+                                 invoice_id: invoice17.id)
+
       item18 = Item.create!(name: 'fak121212e', description: 'T121212ing', unit_price: 30, merchant_id: merchant4.id)
       invoice18 = Invoice.create!(status: 1, customer_id: customer6.id)
-      transaction18 = Transaction.create!(credit_card_number: '121987654', credit_card_expiration_date: '02/07', invoice_id: invoice18.id)
-      ii18 = InvoiceItem.create!(quantity: 5, unit_price: item18.unit_price, item_id: item18.id, invoice_id: invoice18.id)
-      
-  
+      transaction18 = Transaction.create!(credit_card_number: '121987654', credit_card_expiration_date: '02/07',
+                                          invoice_id: invoice18.id)
+      ii18 = InvoiceItem.create!(quantity: 5, unit_price: item18.unit_price, item_id: item18.id,
+                                 invoice_id: invoice18.id)
+
       item19 = Item.create!(name: 'fak121212e', description: 'T121212ing', unit_price: 30, merchant_id: merchant5.id)
       invoice19 = Invoice.create!(status: 1, customer_id: @customer1.id)
-      transaction19 = Transaction.create!(credit_card_number: '121987654', credit_card_expiration_date: '02/07', invoice_id: invoice19.id)
-      ii19 = InvoiceItem.create!(quantity: 5, unit_price: item19.unit_price, item_id: item19.id, invoice_id: invoice19.id)
-  
-  
+      transaction19 = Transaction.create!(credit_card_number: '121987654', credit_card_expiration_date: '02/07',
+                                          invoice_id: invoice19.id)
+      ii19 = InvoiceItem.create!(quantity: 5, unit_price: item19.unit_price, item_id: item19.id,
+                                 invoice_id: invoice19.id)
+
       item20 = Item.create!(name: 'fak121212e', description: 'T121212ing', unit_price: 30, merchant_id: merchant5.id)
       invoice20 = Invoice.create!(status: 1, customer_id: customer3.id)
-      transaction20 = Transaction.create!(credit_card_number: '121987654', credit_card_expiration_date: '02/07', invoice_id: invoice20.id)
-      ii20 = InvoiceItem.create!(quantity: 5, unit_price: item20.unit_price, item_id: item20.id, invoice_id: invoice20.id)
-      
+      transaction20 = Transaction.create!(credit_card_number: '121987654', credit_card_expiration_date: '02/07',
+                                          invoice_id: invoice20.id)
+      ii20 = InvoiceItem.create!(quantity: 5, unit_price: item20.unit_price, item_id: item20.id,
+                                 invoice_id: invoice20.id)
 
       expect(Merchant.top5_merchants).to eq([@merchant1, @merchant2, merchant3, merchant4, merchant5])
     end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -255,9 +255,16 @@ RSpec.describe Merchant do
             FactoryBot.create(:transaction, invoice_id: invoice.id, result: 1)
           end
 
+          merchant2 = FactoryBot.create(:merchant)
+          items2 = FactoryBot.create_list(:item, 10, merchant_id: merchant2.id)
+          items2.each_with_index do |item, index|
+            FactoryBot.create_list(:invoice_item, 2, item_id: item.id, quantity: 1, unit_price: (index * 10))
+          end
+          Invoice.last(20).each do |invoice|
+            FactoryBot.create(:transaction, invoice_id: invoice.id, result: 1)
+          end
+
           expect(merchant.top_5_items).to eq(items.last(5).reverse)
-          # binding.pry
-          # expect(merchant.top_5_items.first.total_revenue).to eq(items)
         end
       end
     end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -249,13 +249,13 @@ RSpec.describe Merchant do
           merchant = FactoryBot.create(:merchant)
           items = FactoryBot.create_list(:item, 10, merchant_id: merchant.id)
           items.each_with_index do |item, index|
-            FactoryBot.create_list(:invoice_item, 2, item_id: item.id, unit_price: (index * 10))
+            FactoryBot.create_list(:invoice_item, 2, item_id: item.id, quantity: 1, unit_price: (index * 10))
           end
           Invoice.all.each_with_index do |invoice, _index|
             FactoryBot.create(:transaction, invoice_id: invoice.id, result: 1)
           end
 
-          expect(merchant.top_5_items).to eq(items.last(5))
+          expect(merchant.top_5_items).to eq(items.last(5).reverse)
         end
       end
     end


### PR DESCRIPTION
This PR broke a test in spec/features/merchants/items/show_spec.rb for user story 7 due to an ambiguous match. This was corrected with a within block. A transaction to item relationship was created to get the AR query to work for top 5 merchant items.

This PR completes the following user story:

Merchant Items Index: 5 most popular items
As a merchant
When I visit my items index page
Then I see the names of the top 5 most popular items ranked by total revenue generated
And I see that each item name links to my merchant item show page for that item
And I see the total revenue generated next to each item name

Notes on Revenue Calculation:

Only invoices with at least one successful transaction should count towards revenue
Revenue for an invoice should be calculated as the sum of the revenue of all invoice items
Revenue for an invoice item should be calculated as the invoice item unit price multiplied by the quantity (do not use the item unit price)