### PR TITLE
Top Item's Best Day - Kr user story 13

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,7 @@ group :development, :test do
   gem 'pry-nav'
   gem 'table_print'
   gem 'factory_bot_rails'
+  gem 'groupdate'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,6 +80,8 @@ GEM
     ffi (1.15.5)
     globalid (1.0.0)
       activesupport (>= 5.0)
+    groupdate (6.1.0)
+      activesupport (>= 5.2)
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
     jbuilder (2.11.5)
@@ -235,6 +237,7 @@ DEPENDENCIES
   capybara
   coffee-rails (~> 4.2)
   factory_bot_rails
+  groupdate
   jbuilder (~> 2.5)
   launchy
   listen (>= 3.0.5, < 3.2)

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -4,4 +4,16 @@ class Item < ApplicationRecord
   has_many :invoices, through: :invoice_items
   has_many :customers, through: :invoices
   has_many :transactions, through: :invoices
+
+  def top_sales_date
+    require 'pry'; binding.pry
+    invoices
+      .joins(:transactions)
+      .where("transaction.result = ?", 1)
+      .select('invoices.created_at, sum(invoice_items.quantity) as invoice_item_count')
+      .group(:id)
+      .order('invoice_item_count desc')
+      .first
+      .created_at
+  end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -6,14 +6,18 @@ class Item < ApplicationRecord
   has_many :transactions, through: :invoices
 
   def top_sales_date
-    require 'pry'; binding.pry
+    # require 'pry'; binding.pry
     invoices
       .joins(:transactions)
-      .where("transaction.result = ?", 1)
-      .select('invoices.created_at, sum(invoice_items.quantity) as invoice_item_count')
-      .group(:id)
-      .order('invoice_item_count desc')
+      .where("transactions.result = ?", 1)
+      .select("
+        sum(invoice_items.quantity*invoice_items.unit_price) as revenue,
+        DATE_TRUNC('day', invoices.created_at) as day
+        ")
+      .group(:day)
+      .order(revenue: :desc, day: :desc)
       .first
-      .created_at
+      .day
+      .to_date
   end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -6,7 +6,6 @@ class Item < ApplicationRecord
   has_many :transactions, through: :invoices
 
   def top_sales_date
-    # require 'pry'; binding.pry
     invoices
       .joins(:transactions)
       .where("transactions.result = ?", 1)

--- a/app/views/merchant_items/index.html.erb
+++ b/app/views/merchant_items/index.html.erb
@@ -24,6 +24,9 @@
 
 <section id="top-5-items">
   <% @merchant.top_5_items.each do |item| %>
-    <p><%= link_to item.name, merchant_item_path(@merchant, item) %> Total Revenue: <%= item.total_revenue %></p>
+    <p>
+      <%= link_to item.name, merchant_item_path(@merchant, item) %> Total Revenue: <%= item.total_revenue %>
+      Top selling date for <%=item.name%> was <%=item.top_sales_date%>
+    </p>
   <% end %>
 </section>

--- a/spec/features/merchants/items/index_spec.rb
+++ b/spec/features/merchants/items/index_spec.rb
@@ -165,7 +165,7 @@ RSpec.describe 'merchant items index page' do
 
       mariah.top_5_items.each do |item|
         within('#top-5-items') do
-          expect(page).to have_content("Top selling date for #{item} was #{item.top_sales_date(mariah)}")
+          expect(page).to have_content("Top selling date for #{item.name} was #{item.top_sales_date}")
         end
       end
     end

--- a/spec/features/merchants/items/index_spec.rb
+++ b/spec/features/merchants/items/index_spec.rb
@@ -143,5 +143,31 @@ RSpec.describe 'merchant items index page' do
         end
       end
     end
+    #     Merchant Items Index: Top Item's Best Day
+    # As a merchant
+    # When I visit my items index page
+    # Then next to each of the 5 most popular items I see the date with the most sales for each item.
+    # And I see a label “Top selling date for was "
+
+    # NOTE: use the invoice date. If there are multiple days with equal number of sales, return the most recent day.
+    #   end
+    it 'lists date with most sales' do
+      mariah = Merchant.create!(name: 'Mariah Ahmed')
+      items = FactoryBot.create_list(:item, 10, merchant_id: mariah.id)
+      items.each_with_index do |item, index|
+        FactoryBot.create_list(:invoice_item, 2, item_id: item.id, quantity: 1, unit_price: (index * 10))
+      end
+      Invoice.all.each_with_index do |invoice, index|
+        FactoryBot.create(:transaction, invoice_id: invoice.id, result: 1, created_at: Time.now - index.days)
+      end
+
+      visit merchant_item_index_path(mariah)
+
+      mariah.top_5_items.each do |item|
+        within('#top-5-items') do
+          expect(page).to have_content("Top selling date for #{item} was #{item.top_sales_date(mariah)}")
+        end
+      end
+    end
   end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -1,11 +1,37 @@
 require 'rails_helper'
 
 RSpec.describe Item do
-  describe "Relationships" do
-    it {should belong_to :merchant} 
-    it {should have_many :invoice_items} 
-    it {should have_many(:invoices).through(:invoice_items)} 
-    it {should have_many(:customers).through(:invoices)}
-    it {should have_many(:transactions).through(:invoices)}
+  describe 'Relationships' do
+    it { should belong_to :merchant }
+    it { should have_many :invoice_items }
+    it { should have_many(:invoices).through(:invoice_items) }
+    it { should have_many(:customers).through(:invoices) }
+    it { should have_many(:transactions).through(:invoices) }
+  end
+
+  describe 'instance methods' do
+    describe '#top_sales_date' do
+      #     As a merchant
+      # When I visit my items index page
+      # Then next to each of the 5 most popular items I see the date with the most sales for each item.
+      # And I see a label “Top selling date for was "
+
+      # NOTE: use the invoice date. If there are multiple days with equal number of sales, return the most recent day.
+      it 'returns the top sales date for a merchant' do
+        mariah = Merchant.create!(name: 'Mariah Ahmed')
+        customer = FactoryBot.create(:customer)
+        item = Item.create!(merchant_id: mariah.id)
+        3.times { Invoice.create!(created_at: Time.now - 1.days, customer_id: customer.id) }
+        4.times { Invoice.create!(created_at: Time.now - 3.days, customer_id: customer.id) }
+        6.times { Invoice.create!(created_at: Time.now - 9.days, customer_id: customer.id) }
+
+        Invoice.all.each do |invoice|
+          FactoryBot.create(:transaction, invoice_id: invoice.id, result: 1)
+          FactoryBot.create(:invoice_item, invoice_id: invoice.id, item_id: item.id, quantity: 1)
+        end
+
+        expect(item.top_sales_date).to eq(Time.now - 9.days)
+      end
+    end
   end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -11,12 +11,6 @@ RSpec.describe Item do
 
   describe 'instance methods' do
     describe '#top_sales_date' do
-      #     As a merchant
-      # When I visit my items index page
-      # Then next to each of the 5 most popular items I see the date with the most sales for each item.
-      # And I see a label “Top selling date for was "
-
-      # NOTE: use the invoice date. If there are multiple days with equal number of sales, return the most recent day.
       it 'returns the top sales date for a merchant' do
         mariah = Merchant.create!(name: 'Mariah Ahmed')
         customer = FactoryBot.create(:customer)
@@ -30,7 +24,7 @@ RSpec.describe Item do
           FactoryBot.create(:invoice_item, invoice_id: invoice.id, item_id: item.id, quantity: 1, unit_price: 1)
         end
 
-        expect(item.top_sales_date).to eq((Time.now - 9.days).to_date)
+        expect(item.top_sales_date).to eq((Invoice.last.created_at).to_date)
       end
     end
   end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -27,10 +27,10 @@ RSpec.describe Item do
 
         Invoice.all.each do |invoice|
           FactoryBot.create(:transaction, invoice_id: invoice.id, result: 1)
-          FactoryBot.create(:invoice_item, invoice_id: invoice.id, item_id: item.id, quantity: 1)
+          FactoryBot.create(:invoice_item, invoice_id: invoice.id, item_id: item.id, quantity: 1, unit_price: 1)
         end
 
-        expect(item.top_sales_date).to eq(Time.now - 9.days)
+        expect(item.top_sales_date).to eq((Time.now - 9.days).to_date)
       end
     end
   end


### PR DESCRIPTION
Merchant Items Index: Top Item's Best Day
As a merchant
When I visit my items index page
Then next to each of the 5 most popular items I see the date with the most sales for each item.
And I see a label “Top selling date for was "

Note: use the invoice date. If there are multiple days with equal number of sales, return the most recent day.